### PR TITLE
Fix error in help message

### DIFF
--- a/src/smudgeplot/cli.py
+++ b/src/smudgeplot/cli.py
@@ -220,7 +220,7 @@ class Parser:
         argparser.add_argument(
             "--format",
             default="png",
-            help="Output format for the plots (default pdf)",
+            help="Output format for the plots (default png)",
             choices=["pdf", "png"],
         )
         argparser.add_argument(


### PR DESCRIPTION
Default is set to png, but help message said pdf